### PR TITLE
Add option to clear Nuget cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,4 +17,4 @@
 ## Pull Requests
 
 1. Fork the project
-1. Submit a pull request
+1. Submit a pull request to the `develop` branch

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ See [Types of portability in .Net Core][] for more information on how to make th
 
 Also note that if you are using a `manifest.yml` file in your application, you can [specify the path][] in your manifest.yml to point to the publish output folder so that you don't have to be in that folder to push the application to Cloud Foundry.
 
+## Clearing NuGet package cache
+
+In some cases, it may be necessary to clear the NuGet packages which are cached in the buildpack.  For example, if you have added pre-release packages to test a new feature and then decided to revert back to the main NuGet feed, those packages may need to be removed from the cache to avoid conflicts.  To clear the NuGet cache, set an environment variable named `CACHE_NUGET_PACKAGES` to `false` in your manifest.yml file and push the application.  This will disable caching NuGet packages in the buildpack.
+
+```yml
+---
+applications:
+- name: sample-aspnetcore-app
+  memory: 512M
+  env:
+    CACHE_NUGET_PACKAGES: false
+```
+
 ## Building
 
 These steps only apply to admins who wish to install the buildpack into their Cloud Foundry deployment. They are meant to be run in a Linux shell and assume that git, Ruby, and the bundler gem are already installed.

--- a/cf_spec/unit/buildpack/compile/installers/bower_installer_spec.rb
+++ b/cf_spec/unit/buildpack/compile/installers/bower_installer_spec.rb
@@ -28,14 +28,14 @@ describe AspNetCoreBuildpack::BowerInstaller do
   subject(:installer) { described_class.new(dir, cache_dir, shell) }
 
   describe '#cached?' do
-    context 'cache directory exists in the build directory' do
+    context 'cache directory exists in the buildpack cache' do
       before do
-        FileUtils.mkdir_p(File.join(dir, '.node', 'node-v6.3.0-linux-x64', 'lib', 'node_modules', 'bower'))
+        FileUtils.mkdir_p(File.join(cache_dir, '.node', 'node-v6.3.0-linux-x64', 'lib', 'node_modules', 'bower'))
       end
 
       context 'cached version is the same as the current version being installed' do
         before do
-          File.open(File.join(dir, '.node', 'node-v6.3.0-linux-x64', 'lib', 'node_modules', 'bower', 'VERSION'), 'w') do |f|
+          File.open(File.join(cache_dir, '.node', 'node-v6.3.0-linux-x64', 'lib', 'node_modules', 'bower', 'VERSION'), 'w') do |f|
             f.write '1.7.9'
           end
         end
@@ -47,7 +47,7 @@ describe AspNetCoreBuildpack::BowerInstaller do
 
       context 'cached version is different than the current version being installed' do
         before do
-          File.open(File.join(dir, '.node', 'node-v6.3.0-linux-x64', 'lib', 'node_modules', 'bower', 'VERSION'), 'w') do |f|
+          File.open(File.join(cache_dir, '.node', 'node-v6.3.0-linux-x64', 'lib', 'node_modules', 'bower', 'VERSION'), 'w') do |f|
             f.write '1.0.0-preview1-002702'
           end
         end

--- a/cf_spec/unit/buildpack/compile/installers/dotnet_installer_spec.rb
+++ b/cf_spec/unit/buildpack/compile/installers/dotnet_installer_spec.rb
@@ -28,14 +28,14 @@ describe AspNetCoreBuildpack::DotnetInstaller do
   subject(:installer) { described_class.new(dir, cache_dir, shell) }
 
   describe '#cached?' do
-    context 'cache directory exists in the build directory' do
+    context 'cache directory exists in the buildpack cache' do
       before do
-        FileUtils.mkdir_p(File.join(dir, '.dotnet'))
+        FileUtils.mkdir_p(File.join(cache_dir, '.dotnet'))
       end
 
       context 'cached version is the same as the current version being installed' do
         before do
-          File.open(File.join(dir, '.dotnet', 'VERSION'), 'w') do |f|
+          File.open(File.join(cache_dir, '.dotnet', 'VERSION'), 'w') do |f|
             f.write '1.0.0-preview2-003121'
           end
         end
@@ -48,7 +48,7 @@ describe AspNetCoreBuildpack::DotnetInstaller do
 
       context 'cached version is different than the current version being installed' do
         before do
-          File.open(File.join(dir, '.dotnet', 'VERSION'), 'w') do |f|
+          File.open(File.join(cache_dir, '.dotnet', 'VERSION'), 'w') do |f|
             f.write '1.0.0-preview1-002702'
           end
         end

--- a/cf_spec/unit/buildpack/compile/installers/libunwind_installer_spec.rb
+++ b/cf_spec/unit/buildpack/compile/installers/libunwind_installer_spec.rb
@@ -34,14 +34,14 @@ describe AspNetCoreBuildpack::LibunwindInstaller do
   end
 
   describe '#cached?' do
-    context 'cache directory exists in the build directory' do
+    context 'cache directory exists in the buildpack cache' do
       before do
-        FileUtils.mkdir_p(File.join(dir, 'libunwind'))
+        FileUtils.mkdir_p(File.join(cache_dir, 'libunwind'))
       end
 
       context 'cached version is the same as the current version being installed' do
         before do
-          File.open(File.join(dir, 'libunwind', 'VERSION'), 'w') do |f|
+          File.open(File.join(cache_dir, 'libunwind', 'VERSION'), 'w') do |f|
             f.write '1.1'
           end
         end
@@ -53,7 +53,7 @@ describe AspNetCoreBuildpack::LibunwindInstaller do
 
       context 'cached version is different than the current version being installed' do
         before do
-          File.open(File.join(dir, 'libunwind', 'VERSION'), 'w') do |f|
+          File.open(File.join(cache_dir, 'libunwind', 'VERSION'), 'w') do |f|
             f.write '1.0.0-preview1-002702'
           end
         end

--- a/cf_spec/unit/buildpack/compile/installers/nodejs_installer_spec.rb
+++ b/cf_spec/unit/buildpack/compile/installers/nodejs_installer_spec.rb
@@ -28,9 +28,9 @@ describe AspNetCoreBuildpack::NodeJsInstaller do
   subject(:installer) { described_class.new(dir, cache_dir, shell) }
 
   describe '#cached?' do
-    context 'cache directory exists in the build directory' do
+    context 'cache directory exists in the buildpack cache' do
       before do
-        FileUtils.mkdir_p(File.join(dir, '.node', 'node-v6.3.0-linux-x64', 'bin'))
+        FileUtils.mkdir_p(File.join(cache_dir, '.node', 'node-v6.3.0-linux-x64', 'bin'))
       end
 
       it 'returns true' do

--- a/lib/buildpack/compile/compiler.rb
+++ b/lib/buildpack/compile/compiler.rb
@@ -26,6 +26,7 @@ require 'pathname'
 
 module AspNetCoreBuildpack
   class Compiler
+    CACHE_NUGET_PACKAGES_VAR = 'CACHE_NUGET_PACKAGES'.freeze
     NUGET_CACHE_DIR = '.nuget'.freeze
 
     def initialize(build_dir, cache_dir, copier, installers, out)
@@ -36,12 +37,15 @@ module AspNetCoreBuildpack
       @app_dir = AppDir.new(@build_dir)
       @shell = AspNetCoreBuildpack.shell
       @installers = installers
+      @dotnet = installers.find { |installer| /(.*)::DotnetInstaller/.match(installer.class.name) }
     end
 
     def compile
       puts "ASP.NET Core buildpack version: #{BuildpackVersion.new.version}\n"
       puts "ASP.NET Core buildpack starting compile\n"
       step('Restoring files from buildpack cache', method(:restore_cache))
+      step('Clearing NuGet packages cache', method(:clear_nuget_cache)) if should_clear_nuget_cache?
+      step('Restoring NuGet packages cache', method(:restore_nuget_cache))
       run_installers
       step('Restoring dependencies with Dotnet CLI', @dotnet.method(:restore)) if dotnet_should_restore
       step('Saving to buildpack cache', method(:save_cache))
@@ -54,13 +58,21 @@ module AspNetCoreBuildpack
 
     private
 
+    def clear_nuget_cache(_out)
+      FileUtils.rm_rf(File.join(cache_dir, NUGET_CACHE_DIR))
+    end
+
     def dotnet_should_restore
       dotnet.should_restore(@app_dir) unless dotnet.nil?
     end
 
+    def nuget_cache_is_valid?
+      return false if @dotnet.nil? || !File.exist?(File.join(cache_dir, NUGET_CACHE_DIR))
+      !@dotnet.should_install(@app_dir)
+    end
+
     def run_installers
       @installers.each do |installer|
-        @dotnet = installer if /(.*)::DotnetInstaller/.match(installer.class.name)
         step(installer.install_description, installer.method(:install)) if installer.should_install(@app_dir)
       end
     end
@@ -69,14 +81,25 @@ module AspNetCoreBuildpack
       @installers.map(&:cache_dir).compact.each do |installer_cache_dir|
         copier.cp(File.join(cache_dir, installer_cache_dir), build_dir, out) if File.exist? File.join(cache_dir, installer_cache_dir)
       end
-      copier.cp(File.join(cache_dir, NUGET_CACHE_DIR), build_dir, out) if File.exist? File.join(cache_dir, NUGET_CACHE_DIR)
+    end
+
+    def restore_nuget_cache(out)
+      copier.cp(File.join(cache_dir, NUGET_CACHE_DIR), build_dir, out) if nuget_cache_is_valid?
     end
 
     def save_cache(out)
-      @installers.map(&:cache_dir).compact.each do |installer_cache_dir|
-        copier.cp(File.join(build_dir, installer_cache_dir), cache_dir, out) if File.exist? File.join(build_dir, installer_cache_dir)
+      @installers.select { |installer| !installer.nil? && !installer.cache_dir.nil? }.compact.each do |installer|
+        copier.cp(File.join(build_dir, installer.cache_dir), cache_dir, out) if File.exist?(File.join(build_dir, installer.cache_dir)) && !installer.cached?
       end
-      copier.cp(File.join(build_dir, NUGET_CACHE_DIR), cache_dir, out) if File.exist? File.join(build_dir, NUGET_CACHE_DIR)
+      copier.cp(File.join(build_dir, NUGET_CACHE_DIR), cache_dir, out) if should_save_nuget_cache?
+    end
+
+    def should_clear_nuget_cache?
+      File.exist?(File.join(cache_dir, NUGET_CACHE_DIR)) && (ENV[CACHE_NUGET_PACKAGES_VAR] == 'false' || !nuget_cache_is_valid?)
+    end
+
+    def should_save_nuget_cache?
+      File.exist?(File.join(build_dir, NUGET_CACHE_DIR)) && ENV[CACHE_NUGET_PACKAGES_VAR] != 'false'
     end
 
     def step(description, method)

--- a/lib/buildpack/compile/installers/dotnet_installer.rb
+++ b/lib/buildpack/compile/installers/dotnet_installer.rb
@@ -32,6 +32,13 @@ module AspNetCoreBuildpack
       @shell = shell
     end
 
+    def cached?
+      # File.open can't create the directory structure
+      return false unless File.exist? File.join(@bp_cache_dir, CACHE_DIR)
+      cached_version = File.open(cached_version_file, File::RDONLY | File::CREAT).select { |line| line.chomp == version }
+      !cached_version.empty?
+    end
+
     def install(out)
       @version = DotnetVersion.new.version(@build_dir, out)
       dest_dir = File.join(@build_dir, CACHE_DIR)
@@ -79,13 +86,6 @@ module AspNetCoreBuildpack
 
     def cache_folder
       File.join(bp_cache_dir, CACHE_DIR)
-    end
-
-    def cached?
-      # File.open can't create the directory structure
-      return false unless File.exist? File.join(@build_dir, CACHE_DIR)
-      cached_version = File.open(version_file, File::RDONLY | File::CREAT).select { |line| line.chomp == version }
-      !cached_version.empty?
     end
 
     def dependency_name

--- a/lib/buildpack/compile/installers/installer.rb
+++ b/lib/buildpack/compile/installers/installer.rb
@@ -28,6 +28,10 @@ module AspNetCoreBuildpack
       1
     end
 
+    def cached?
+      false
+    end
+
     def cache_dir
       nil
     end
@@ -53,6 +57,10 @@ module AspNetCoreBuildpack
     def buildpack_root
       current_dir = File.expand_path(File.dirname(__FILE__))
       File.dirname(File.dirname(File.dirname(File.dirname(current_dir))))
+    end
+
+    def cached_version_file
+      File.join(@bp_cache_dir, cache_dir, VERSION_FILE) unless cache_dir.nil? || @bp_cache_dir.nil?
     end
 
     def version_file

--- a/lib/buildpack/compile/installers/libunwind_installer.rb
+++ b/lib/buildpack/compile/installers/libunwind_installer.rb
@@ -35,6 +35,13 @@ module AspNetCoreBuildpack
       @shell = shell
     end
 
+    def cached?
+      # File.open can't create the directory structure
+      return false unless File.exist? File.join(@bp_cache_dir, CACHE_DIR)
+      cached_version = File.open(cached_version_file, File::RDONLY | File::CREAT).select { |line| line.chomp == VERSION }
+      !cached_version.empty?
+    end
+
     def install(out)
       dest_dir = File.join(@build_dir, CACHE_DIR)
 
@@ -61,13 +68,6 @@ module AspNetCoreBuildpack
     end
 
     private
-
-    def cached?
-      # File.open can't create the directory structure
-      return false unless File.exist? File.join(@build_dir, CACHE_DIR)
-      cached_version = File.open(version_file, File::RDONLY | File::CREAT).select { |line| line.chomp == VERSION }
-      !cached_version.empty?
-    end
 
     def dependency_name
       "libunwind-x-#{version}.tar.gz"

--- a/lib/buildpack/compile/installers/nodejs_installer.rb
+++ b/lib/buildpack/compile/installers/nodejs_installer.rb
@@ -36,6 +36,10 @@ module AspNetCoreBuildpack
       @shell = shell
     end
 
+    def cached?
+      File.exist? File.join(@bp_cache_dir, CACHE_DIR, File.basename(dependency_name, '.tar.gz'.freeze), 'bin'.freeze)
+    end
+
     def install(out)
       dest_dir = File.join(@build_dir, CACHE_DIR)
 
@@ -66,10 +70,6 @@ module AspNetCoreBuildpack
 
     def bin_folder
       File.join('$HOME'.freeze, CACHE_DIR, File.basename(dependency_name, '.tar.gz'.freeze), 'bin'.freeze)
-    end
-
-    def cached?
-      File.exist? File.join(@build_dir, CACHE_DIR, File.basename(dependency_name, '.tar.gz'.freeze), 'bin'.freeze)
     end
 
     def dependency_name


### PR DESCRIPTION
Add a `CLEAR_NUGET_CACHE` environment variable to allow clearing the NuGet packages cache.