### PR TITLE
Workaround for memory allocation error

### DIFF
--- a/lib/buildpack/compile/installers/bower_installer.rb
+++ b/lib/buildpack/compile/installers/bower_installer.rb
@@ -46,8 +46,8 @@ module AspNetCoreBuildpack
       write_version_file(VERSION)
     end
 
-    def install_description
-      'Installing Bower'.freeze
+    def name
+      'Bower'.freeze
     end
 
     def should_install(app_dir)

--- a/lib/buildpack/compile/installers/dotnet_installer.rb
+++ b/lib/buildpack/compile/installers/dotnet_installer.rb
@@ -42,8 +42,8 @@ module AspNetCoreBuildpack
       write_version_file(@version)
     end
 
-    def install_description
-      'Installing Dotnet CLI'
+    def name
+      'Dotnet CLI'.freeze
     end
 
     def path

--- a/lib/buildpack/compile/installers/installer.rb
+++ b/lib/buildpack/compile/installers/installer.rb
@@ -33,7 +33,11 @@ module AspNetCoreBuildpack
     end
 
     def install_description
-      'Installing'
+      "Installing #{name}"
+    end
+
+    def name
+      nil
     end
 
     def library_path

--- a/lib/buildpack/compile/installers/libunwind_installer.rb
+++ b/lib/buildpack/compile/installers/libunwind_installer.rb
@@ -45,7 +45,11 @@ module AspNetCoreBuildpack
     end
 
     def install_description
-      'Extracting libunwind'
+      'Extracting libunwind'.freeze
+    end
+
+    def name
+      'libunwind'.freeze
     end
 
     def library_path

--- a/lib/buildpack/compile/installers/nodejs_installer.rb
+++ b/lib/buildpack/compile/installers/nodejs_installer.rb
@@ -45,8 +45,8 @@ module AspNetCoreBuildpack
       @shell.exec("mkdir -p #{dest_dir}; tar xzf /tmp/#{dependency_name} -C #{dest_dir}", out)
     end
 
-    def install_description
-      'Installing Node.js'.freeze
+    def name
+      'Node.js'.freeze
     end
 
     def path


### PR DESCRIPTION
Occasionally the buildpack fails to copy files to the cache folder when saving to the cache throwing an out of memory exception which causes staging to fail.  This update will allow staging to continue and just skip caching those files when the copy fails.