### PR TITLE
Prepare buildpack for automatic dependency updates

### DIFF
--- a/cf_spec/unit/buildpack/compile/dotnet_version_spec.rb
+++ b/cf_spec/unit/buildpack/compile/dotnet_version_spec.rb
@@ -22,8 +22,8 @@ require 'tmpdir'
 describe AspNetCoreBuildpack::DotnetVersion do
   let(:out) { double(:out) }
   let(:dir) { Dir.mktmpdir }
-  let(:manifest_file) {File.join(dir, 'manifest.yml')}
-  let(:dotnet_versions_file) {File.join(dir, 'dotnet-versions.yml')}
+  let(:manifest_file) { File.join(dir, 'manifest.yml') }
+  let(:dotnet_versions_file) { File.join(dir, 'dotnet-versions.yml') }
 
   let(:dotnet_versions_yml) do
     <<~YAML

--- a/cf_spec/unit/buildpack/compile/dotnet_version_spec.rb
+++ b/cf_spec/unit/buildpack/compile/dotnet_version_spec.rb
@@ -26,31 +26,31 @@ describe AspNetCoreBuildpack::DotnetVersion do
   let(:dotnet_versions_file) { File.join(dir, 'dotnet-versions.yml') }
 
   let(:dotnet_versions_yml) do
-    <<~YAML
-       ---
-       - dotnet: sdk-version-1
-         framework: 0.9.99
-       - dotnet: sdk-version-2
-         framework: 1.0.0
-       - dotnet: sdk-version-3
-         framework: 1.0.1
-       YAML
+    <<-YAML
+---
+- dotnet: sdk-version-1
+  framework: 0.9.99
+- dotnet: sdk-version-2
+  framework: 1.0.0
+- dotnet: sdk-version-3
+  framework: 1.0.1
+  YAML
   end
 
   let(:manifest_yml) do
-    <<~YAML
-       ---
-       default_versions:
-         - name: dotnet
-           version: sdk-version-3
-       dependencies:
-         - name: dotnet
-           version: sdk-version-1
-         - name: dotnet
-           version: sdk-version-2
-         - name: dotnet
-           version: sdk-version-3
-       YAML
+    <<-YAML
+---
+default_versions:
+- name: dotnet
+  version: sdk-version-3
+dependencies:
+- name: dotnet
+  version: sdk-version-1
+- name: dotnet
+  version: sdk-version-2
+- name: dotnet
+  version: sdk-version-3
+  YAML
   end
 
   let(:latest_version) { 'sdk-version-3'.freeze }

--- a/cf_spec/unit/buildpack/compile/dotnet_version_spec.rb
+++ b/cf_spec/unit/buildpack/compile/dotnet_version_spec.rb
@@ -22,13 +22,55 @@ require 'tmpdir'
 describe AspNetCoreBuildpack::DotnetVersion do
   let(:out) { double(:out) }
   let(:dir) { Dir.mktmpdir }
-  let(:latest_version) { '1.0.0-preview2-003131'.freeze }
+  let(:manifest_file) {File.join(dir, 'manifest.yml')}
+  let(:dotnet_versions_file) {File.join(dir, 'dotnet-versions.yml')}
+
+  let(:dotnet_versions_yml) do
+    <<~YAML
+       ---
+       - dotnet: sdk-version-1
+         framework: 0.9.99
+       - dotnet: sdk-version-2
+         framework: 1.0.0
+       - dotnet: sdk-version-3
+         framework: 1.0.1
+       YAML
+  end
+
+  let(:manifest_yml) do
+    <<~YAML
+       ---
+       default_versions:
+         - name: dotnet
+           version: sdk-version-3
+       dependencies:
+         - name: dotnet
+           version: sdk-version-1
+         - name: dotnet
+           version: sdk-version-2
+         - name: dotnet
+           version: sdk-version-3
+       YAML
+  end
+
+  let(:latest_version) { 'sdk-version-3'.freeze }
+
+  before do
+    File.write(dotnet_versions_file, dotnet_versions_yml)
+    File.write(manifest_file, manifest_yml)
+  end
+
+  after do
+    FileUtils.rm_rf(dir)
+  end
+
+  subject { described_class.new(dir, manifest_file, dotnet_versions_file, out) }
 
   describe '#version' do
     context 'global.json does not exist' do
       context '*.runtimeconfig.json does not exist' do
         it 'resolves to the latest version' do
-          expect(subject.version(dir, out)).to eq(latest_version)
+          expect(subject.version).to eq(latest_version)
         end
       end
 
@@ -39,18 +81,29 @@ describe AspNetCoreBuildpack::DotnetVersion do
         end
 
         it 'resolves to the latest version' do
-          expect(subject.version(dir, out)).to eq(latest_version)
+          expect(subject.version).to eq(latest_version)
+        end
+      end
+
+      context '*.runtimeconfig.json has non-included version' do
+        before do
+          json = '{ "runtimeOptions": { "framework": { "name": "Microsoft.NETCore.App", "version": "99.99.99" } } }'
+          IO.write(File.join(dir, 'testapp.runtimeconfig.json'), json)
+        end
+
+        it 'resolves to the latest version' do
+          expect(subject.version).to eq(latest_version)
         end
       end
 
       context 'valid *.runtimeconfig.json exists' do
         before do
-          json = '{ "runtimeOptions": { "framework": { "name": "Microsoft.NETCore.App", "version": "1.0.0-rc2-3002702" } } }'
+          json = '{ "runtimeOptions": { "framework": { "name": "Microsoft.NETCore.App", "version": "1.0.0" } } }'
           IO.write(File.join(dir, 'testapp.runtimeconfig.json'), json)
         end
 
         it 'maps the version specified in *.runtimeconfig.json' do
-          expect(subject.version(dir, out)).to eq('1.0.0-preview1-002702')
+          expect(subject.version).to eq('sdk-version-2')
         end
       end
     end
@@ -62,7 +115,7 @@ describe AspNetCoreBuildpack::DotnetVersion do
       end
 
       it 'resolves to the specified version' do
-        expect(subject.version(dir, out)).to eq('1.0.0-beta1')
+        expect(subject.version).to eq('1.0.0-beta1')
       end
     end
 
@@ -73,7 +126,7 @@ describe AspNetCoreBuildpack::DotnetVersion do
       end
 
       it 'resolves to the specified version' do
-        expect(subject.version(dir, out)).to eq('1.0.0-beta1')
+        expect(subject.version).to eq('1.0.0-beta1')
       end
     end
 
@@ -85,7 +138,7 @@ describe AspNetCoreBuildpack::DotnetVersion do
 
       it 'warns and resolves to the latest version' do
         expect(out).to receive(:warn).with("File #{dir}/global.json is not valid JSON")
-        expect(subject.version(dir, out)).to eq(latest_version)
+        expect(subject.version).to eq(latest_version)
       end
     end
 
@@ -96,7 +149,7 @@ describe AspNetCoreBuildpack::DotnetVersion do
       end
 
       it 'resolves to the latest version' do
-        expect(subject.version(dir, out)).to eq(latest_version)
+        expect(subject.version).to eq(latest_version)
       end
     end
   end

--- a/dotnet-versions.yml
+++ b/dotnet-versions.yml
@@ -1,0 +1,7 @@
+---
+- dotnet: 1.0.0-preview1-002702
+  framework: 1.0.0-rc2-3002702
+- dotnet: 1.0.0-preview2-003121
+  framework: 1.0.0
+- dotnet: 1.0.0-preview2-003131
+  framework: 1.0.1

--- a/lib/buildpack/compile/dotnet_version.rb
+++ b/lib/buildpack/compile/dotnet_version.rb
@@ -63,8 +63,8 @@ module AspNetCoreBuildpack
           framework = global_props['runtimeOptions']['framework']
 
           if framework.key?('version')
-            version = @dotnet_versions.find do |version|
-              version['framework'] == framework['version']
+            version = @dotnet_versions.find do |ver|
+              ver['framework'] == framework['version']
             end
             return version['dotnet'] unless version.nil?
           end

--- a/lib/buildpack/compile/installers/dotnet_installer.rb
+++ b/lib/buildpack/compile/installers/dotnet_installer.rb
@@ -33,7 +33,12 @@ module AspNetCoreBuildpack
     end
 
     def install(out)
-      @version = DotnetVersion.new.version(@build_dir, out)
+      buildpack_root = File.join(File.dirname(__FILE__), '..', '..', '..','..')
+      manifest_file = File.join(buildpack_root, 'manifest.yml')
+      dotnet_versions_file = File.join(buildpack_root, 'dotnet-versions.yml')
+
+      @version = DotnetVersion.new(@build_dir, manifest_file, dotnet_versions_file, out).version
+
       dest_dir = File.join(@build_dir, CACHE_DIR)
 
       out.print("dotnet version: #{version}")

--- a/lib/buildpack/compile/installers/dotnet_installer.rb
+++ b/lib/buildpack/compile/installers/dotnet_installer.rb
@@ -33,7 +33,7 @@ module AspNetCoreBuildpack
     end
 
     def install(out)
-      buildpack_root = File.join(File.dirname(__FILE__), '..', '..', '..','..')
+      buildpack_root = File.join(File.dirname(__FILE__), '..', '..', '..', '..')
       manifest_file = File.join(buildpack_root, 'manifest.yml')
       dotnet_versions_file = File.join(buildpack_root, 'dotnet-versions.yml')
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,10 @@
 ---
 language: dotnet-core
 
+default_versions:
+  - name: dotnet
+    version: 1.0.0-preview2-003131
+
 url_to_dependency_map:
   - match: libunwind-(.*)-(\d+\.\d+)
     name: libunwind


### PR DESCRIPTION
We would like to add the dotnet dependency to the [pipeline](https://buildpacks.ci.cf-app.com/teams/main/pipelines/binary-builder) which automatically watches for new versions of a dependency, builds them, and adds them to their corresponding buildpack. 

In order for this last step to work smoothly, we need to make sure we're only updating config / yml files instead of Ruby code. For this reason, we've updated the DotnetVersion class to:
  1. Use a compile-extensions [script](https://github.com/cloudfoundry/compile-extensions/blob/master/bin/default_version_for) to determine the default dotnet version
  2. Move the SDK version -> Framework version mapping into a new config file, `dotnet-versions.yml`

There should be no observed change in behavior.

Pivotal Tracker story: https://www.pivotaltracker.com/story/show/130932637

Signed-off-by: Anna Thornton <athornton@pivotal.io>