### PR TITLE
Add node 6.7.0, remove node 6.3.0

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -45,11 +45,11 @@ dependencies:
     uri: https://go.microsoft.com/fwlink/?LinkID=827536
     md5: c5880e1fafd17e28d157d32784e1aed1
   - name: nodejs
-    version: 6.3.0
+    version: 6.7.0
     cf_stacks:
       - cflinuxfs2
-    uri: https://nodejs.org/download/release/v6.3.0/node-v6.3.0-linux-x64.tar.gz
-    md5: 41d14f57079c5935a4f0b470abd9f6b6
+    uri: https://buildpacks.cloudfoundry.org/concourse-binaries/node/node-6.7.0-linux-x64.tgz
+    md5: 67785b03200cf7c3b78c2bdfeecfdc67
   - name: bower
     version: 1.7.9
     cf_stacks:


### PR DESCRIPTION
Node 6.3.0 is unpatched for high-value CVEs (USN-3087-1 and USN-3087-2).

This patch replaces the original nodejs.org 6.3.0 binary with a 6.7.0
binary built using the buildpacks CI infrastructure.

This is the same binary used in the Cloud Foudnry NodeJS and Ruby buildpacks.

[#131987641]

Signed-off-by: Anna Thornton <athornton@pivotal.io>